### PR TITLE
Fix EpisodeData constructor field name

### DIFF
--- a/quasimetric_rl/data/base.py
+++ b/quasimetric_rl/data/base.py
@@ -122,7 +122,7 @@ class EpisodeData(MultiEpisodeData):
         next_observations=torch.tensor(next_observations)
         all_observations = torch.cat([observations, next_observations[-1:]], dim=0)
         return cls(
-            episode_length=torch.tensor([observations.shape[0]]),
+            episode_lengths=torch.tensor([observations.shape[0]]),
             all_observations=all_observations,
             actions=torch.tensor(actions),
             rewards=torch.tensor(rewards),


### PR DESCRIPTION
## Summary
- fix EpisodeData.from_simple_trajectory to use `episode_lengths`

## Testing
- `python -m py_compile quasimetric_rl/data/base.py`
- `python -m compileall quasimetric_rl`